### PR TITLE
Added CONT signal after failed attach and after detach (not using gdb pid)

### DIFF
--- a/src/padb
+++ b/src/padb
@@ -6391,6 +6391,7 @@ sub gdb_attach_async_end {
         if ( not find_exe('gdb') ) {
             $gdb->{error} = 'Failed to attach to process (is gdb installed?)';
         }
+        send_cont_signal($pid);
         return;
     }
 
@@ -8813,6 +8814,7 @@ sub global_detach {
             gdb_quit( $proc->{gdb_handle} );
             delete $proc->{gdb_handle};
         }
+        send_cont_signal($proc->{pid});
     }
     return;
 }


### PR DESCRIPTION
This fixes an issue where a parallel application (MPI+OpenMP) would hang, because padb leaves some processes in a tracing state. More explanation about the changes can be found in the comments.

