### PR TITLE
add share/oversubscribe to srun so that slurm does not block launch of this step - problem on newer slurms

### DIFF
--- a/src/padb
+++ b/src/padb
@@ -2642,7 +2642,7 @@ sub slurm_setup_job {
     my %pcmd;
     $pcmd{nprocesses} = $cpus;
     $pcmd{nhosts}     = $nc;
-    $pcmd{command}    = "srun --jobid=$job";
+    $pcmd{command}    = "srun -s --jobid=$job";
     return %pcmd;
 
 }


### PR DESCRIPTION
That in much older slurm versions this is not needed, but it does not hurt either.